### PR TITLE
fix: secure auth, add bcrypt hashing, clean server

### DIFF
--- a/backend/middlewares/auth.mjs
+++ b/backend/middlewares/auth.mjs
@@ -1,74 +1,58 @@
 import jwt from 'jsonwebtoken';
 
+/**
+ * Authentication & authorization middleware
+ * - No default/fallback secret. If JWT_SECRET is not set, middleware returns 500 (server misconfiguration).
+ * - Exports:
+ *    requireAuth(roles = []) -> middleware
+ *    requireRole(...roles) -> middleware generator
+ *    requireAdmin -> shorthand
+ */
+
+const JWT_SECRET = process.env.JWT_SECRET;
+
 export const requireAuth = (roles = []) => (req, res, next) => {
-  const authHeader = req.headers.authorization;
-  if (!authHeader) return res.status(401).json({ success: false, message: 'No token provided', data: null });
-  const token = authHeader.split(' ')[1];
+  if (!JWT_SECRET) {
+    console.error('Server misconfiguration: JWT_SECRET is not set.');
+    return res.apiError('Server misconfiguration: authentication secret not configured', 500);
+  }
+
+  const authHeader = req.headers?.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return res.apiError('No token provided', 401);
+  }
+
+  const token = authHeader.slice(7); // remove 'Bearer '
   try {
-    const payload = jwt.verify(token, process.env.JWT_SECRET || 'changeme');
+    const payload = jwt.verify(token, JWT_SECRET);
     req.user = payload;
-    if (roles.length && !roles.includes(payload.role)) return res.status(403).json({ success: false, message: 'Forbidden', data: null });
-    next();
-  } catch (err) {
-    return res.status(401).json({ success: false, message: 'Invalid token', data: null });
-  }
-};
-/**
- * JWT authentication middleware
- * Verifies JWT tokens and provides role-based access control
- */
-
-import jwt from 'jsonwebtoken';
-
-const JWT_SECRET = process.env.JWT_SECRET || 'changeme';
-
-/**
- * Middleware to verify JWT token and attach user to request
- */
-export const requireAuth = (req, res, next) => {
-  try {
-    const authHeader = req.headers.authorization;
-    
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
-      return res.apiError('No token provided', 401);
-    }
-
-    const token = authHeader.substring(7); // Remove 'Bearer ' prefix
-    
-    try {
-      const decoded = jwt.verify(token, JWT_SECRET);
-      req.user = decoded; // Attach decoded user info to request
-      next();
-    } catch (err) {
-      if (err.name === 'TokenExpiredError') {
-        return res.apiError('Token expired', 401);
-      }
-      return res.apiError('Invalid token', 401);
-    }
-  } catch (error) {
-    return res.apiError('Authentication failed', 401);
-  }
-};
-
-/**
- * Middleware to check if user has required role
- * @param {string[]} roles - Array of allowed roles
- */
-export const requireRole = (...roles) => {
-  return (req, res, next) => {
-    if (!req.user) {
-      return res.apiError('Authentication required', 401);
-    }
-
-    if (!roles.includes(req.user.role)) {
+    if (Array.isArray(roles) && roles.length > 0 && !roles.includes(payload.role)) {
       return res.apiError('Insufficient permissions', 403);
     }
-
-    next();
-  };
+    return next();
+  } catch (err) {
+    if (err && err.name === 'TokenExpiredError') {
+      return res.apiError('Token expired', 401);
+    }
+    return res.apiError('Invalid token', 401);
+  }
 };
 
-/**
- * Middleware to check if user is admin
- */
+export const requireRole = (...roles) => (req, res, next) => {
+  if (!req.user) {
+    return res.apiError('Authentication required', 401);
+  }
+  if (!roles.length) return next();
+  if (!roles.includes(req.user.role)) {
+    return res.apiError('Insufficient permissions', 403);
+  }
+  return next();
+};
+
 export const requireAdmin = requireRole('admin');
+
+export default {
+  requireAuth,
+  requireRole,
+  requireAdmin,
+};


### PR DESCRIPTION
# fix: secure auth, add bcrypt hashing, clean server

This PR applies security and stability fixes:
1) `backend/middlewares/auth.mjs` - remove JWT secret fallback, centralize `requireAuth`/`requireRole`/`requireAdmin`, use `res.apiError` and handle token expiry;
2) `backend/models/User.mjs` - deduplicate model, add bcrypt pre-save hashing and `comparePassword` helper, configurable `SALT_ROUNDS`;
3) `backend/server.mjs` - clean duplicate imports/middleware, single connectDB implementation, production `JWT_SECRET` enforcement, graceful shutdown.

Notes:
- Install bcrypt in backend (npm install bcrypt)
- Ensure response middleware exports `res.apiError`/`res.apiSuccess`
- Set `JWT_SECRET` and `MONGO_URI` in environment for production.